### PR TITLE
Migrate from the localstack CLI to lstk

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,22 +27,20 @@ jobs:
         with:
           node-version: 18
 
+      - name: Install lstk
+        run: npm install -g @localstack/lstk
+
       - name: Start LocalStack
-        uses: LocalStack/setup-localstack@main
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
-          DNS_ADDRESS: 0
-          DEBUG: 1
-        with:
-          use-pro: 'true'
-
-      - name: Install tflocal
-        run: pip install terraform-local
+          LOCALSTACK_DNS_ADDRESS: "0"
+          LOCALSTACK_DEBUG: "1"
+        run: lstk start
 
       - name: Install CDK
         run: |
-          npm install -g aws-cdk-local aws-cdk
-          cdklocal --version
+          npm install -g aws-cdk
+          lstk cdk --version
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,8 +1,13 @@
 name: Create PR Preview
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+  # Disabled: `lstk aws`/`lstk cdk` (used via the Makefile targets that preview-cmd
+  # below calls) always target their own locally-managed emulator and ignore
+  # AWS_ENDPOINT_URL, so they can't reach the remote ephemeral instance this
+  # workflow provisions. Re-enable once that's resolved.
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
 
 jobs:
   preview:
@@ -22,11 +27,13 @@ jobs:
           state-backend: ephemeral
           state-action: start
           include-preview: 'true'
+          # TODO(lstk): no install-lstk equivalent in the setup-localstack action yet —
+          # lstk is installed via npm inside preview-cmd instead.
           install-awslocal: 'true'
           # Multi line commands are folding for some reason, so we enforce new lines
           # For more predictable usage, use script files
           preview-cmd: |
-            npm install -g aws-cdk-local aws-cdk;
+            npm install -g @localstack/lstk aws-cdk;
             make build;
             make bootstrap;
             make deploy;
@@ -34,6 +41,6 @@ jobs:
             make build-frontend;
             make bootstrap-frontend;
             make deploy-frontend;
-            distributionId=$(awslocal cloudfront list-distributions | jq -r '.DistributionList.Items[0].Id');
+            distributionId=$(lstk aws cloudfront list-distributions | jq -r '.DistributionList.Items[0].Id');
             echo LS_PREVIEW_URL=$AWS_ENDPOINT_URL/cloudfront/$distributionId/ >> $GITHUB_ENV;
 

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,7 @@ usage:
 
 ## Install dependencies
 install:
-		@which localstack || pip install localstack
-		@which awslocal || pip install awscli-local
+		@which lstk || npm install -g @localstack/lstk
 
 # Deploy the infrastructure
 build:
@@ -29,7 +28,7 @@ deploy:
 ## Start LocalStack in detached mode
 start:
 		@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
-		@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
+		@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) lstk start --non-interactive
 
 ## export configs for web app
 prepare-frontend-local:
@@ -50,16 +49,16 @@ deploy-frontend:
 ## Stop the Running LocalStack container
 stop:
 		@echo
-		localstack stop
+		lstk stop
 
 ## Make sure the LocalStack container is up
 ready:
 		@echo Waiting on the LocalStack container...
-		@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+		@lstk status && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
 
 ## Save the logs in a separate file, since the LS container will only contain the logs of the last sample run.
 logs:
-		@localstack logs > logs.txt
+		@lstk logs > logs.txt
 
 setup-challenge:
 		yarn install

--- a/README.md
+++ b/README.md
@@ -32,20 +32,20 @@ We are using the following AWS services and their features to build our infrastr
 
 ## Prerequisites
 
-- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
-- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
-- [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`awslocal` wrapper](https://docs.localstack.cloud/user-guide/integrations/aws-cli/#localstack-aws-cli-awslocal).
-- [CDK](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/) with the [`cdklocal`](https://www.npmjs.com/package/aws-cdk-local) wrapper.
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/aws/getting-started/auth-token/) to activate LocalStack.
+- [`lstk` CLI](https://docs.localstack.cloud/aws/developer-tools/running-localstack/lstk/), installed via `npm install -g @localstack/lstk` or `brew install localstack/tap/lstk`.
+- [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/), required by `lstk aws`.
+- [CDK](https://docs.localstack.cloud/user-guide/integrations/aws-cdk/), used via the `lstk cdk` proxy.
 - [Node.js](https://nodejs.org/en/download/) with `yarn` package manager.
 
 Start LocalStack for AWS with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
 
 ```shell
 export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
-EXTRA_CORS_ALLOWED_ORIGINS=* localstack start
+EXTRA_CORS_ALLOWED_ORIGINS=* lstk start
 ```
 
-The `EXTRA_CORS_ALLOWED_ORIGINS` configuration variable allows our website to send requests to the HTTP APIs exposed via the API Gateway. If you prefer running LocalStack in detached mode, you can add the `-d` flag to the `localstack start` command, and use Docker Desktop to view the logs.
+The `EXTRA_CORS_ALLOWED_ORIGINS` configuration variable allows our website to send requests to the HTTP APIs exposed via the API Gateway. If you prefer running LocalStack in detached mode, you can add the `--non-interactive` flag to the `lstk start` command, and use Docker Desktop to view the logs.
 
 ## Instructions
 
@@ -169,6 +169,8 @@ Users can adapt this example workflow to run in their own CI environment. LocalS
 ### Preview environment
 
 This sample further shows off our preview environments feature. Preview environments allow you to deploy your application to a separate environment whenever you want with the right configuration. You can find the workflow in the `.github/workflows/preview.yml` file. You can find more information about preview environments in the [LocalStack documentation](https://docs.localstack.cloud/user-guide/cloud-sandbox/application-previews/).
+
+> This workflow provisions a remote Ephemeral Instance via the `LocalStack/setup-localstack` action, which `lstk` does not support yet. Its automatic `pull_request` trigger has been disabled; it can still be run manually via `workflow_dispatch`.
 
 ## Learn more
 

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.11.18",
-    "aws-cdk": "2.59.0",
+    "aws-cdk": "2.1133.0",
     "typescript": "~4.9.4"
   },
   "dependencies": {

--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "cdk": "tsc && cdk",
-    "cdklocal": "tsc && cdklocal --require-approval never"
+    "cdklocal": "tsc && lstk cdk --require-approval never"
   },
   "devDependencies": {
     "@types/node": "^18.11.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,7 +202,7 @@ __metadata:
   resolution: "@aws-sdk-notes-app/infra@workspace:packages/infra"
   dependencies:
     "@types/node": ^18.11.18
-    aws-cdk: 2.59.0
+    aws-cdk: 2.1133.0
     aws-cdk-lib: 2.59.0
     constructs: 10.1.215
     typescript: ~4.9.4
@@ -2573,17 +2573,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-cdk@npm:2.59.0":
-  version: 2.59.0
-  resolution: "aws-cdk@npm:2.59.0"
-  dependencies:
-    fsevents: 2.3.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
+"aws-cdk@npm:2.1133.0":
+  version: 2.1133.0
+  resolution: "aws-cdk@npm:2.1133.0"
   bin:
     cdk: bin/cdk
-  checksum: 2d405f43d7d1c857ab27e42b861953a3ea4712e57356f556d97382d7ce25749be60896b2a9982d69b60e825dc0a749fc31d31974637c09149a8dea0796d11171
+  checksum: 89525d4e74669a82da3a13386602257780184d200fd4492e3f36ff1e9189118ff3de814e9096bac4b9cc85f9989516e5f94aa71a7e544eb8d544497e127b7f3f
   languageName: node
   linkType: hard
 
@@ -3683,31 +3678,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:2.3.2":
-  version: 2.3.2
-  resolution: "fsevents@npm:2.3.2"
-  dependencies:
-    node-gyp: latest
-  checksum: 97ade64e75091afee5265e6956cb72ba34db7819b4c3e94c431d4be2b19b8bb7a2d4116da417950c3425f17c8fe693d25e20212cac583ac1521ad066b77ae31f
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
 "fsevents@npm:~2.3.2":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: latest
   checksum: 11e6ea6fea15e42461fc55b4b0e4a0a3c654faa567f1877dbd353f39156f69def97a69936d1746619d656c4b93de2238bf731f6085a03a50cabf287c9d024317
-  conditions: os=darwin
-  languageName: node
-  linkType: hard
-
-"fsevents@patch:fsevents@2.3.2#~builtin<compat/fsevents>":
-  version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
-  dependencies:
-    node-gyp: latest
   conditions: os=darwin
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Summary
- Replace `localstack`/`awslocal`/`cdklocal` invocations with `lstk` across the Makefile, README, npm scripts, and CI workflows.
- Replace the `setup-localstack` action in the main CI workflow with `npm install -g @localstack/lstk` + `lstk start`.
- Disable the PR Preview workflow's automatic trigger — Ephemeral Instances / App Preview aren't supported by `lstk` yet (same treatment as the quiz app).
- Remove the dead `tflocal` install step; this repo has no Terraform.

## Testing
- CI workflow run on this branch.

Part of DEVX-1056